### PR TITLE
Fixed syntax error on remove role from user

### DIFF
--- a/Neo4j.AspNetCore.Identity/UserStore.cs
+++ b/Neo4j.AspNetCore.Identity/UserStore.cs
@@ -272,6 +272,8 @@ namespace Neo4j.AspNetCore.Identity
             //check if user has objects that were removed
             if (user.RemovedObjects.Count > 0)
             {
+                // with user u
+                query = query.With("u");
                 //remove each one from db
                 var logins = user.RemovedObjects.OfType<IdentityExternalLogin>().ToList();
                 var existingCount = user.Logins?.Count() ?? 0;


### PR DESCRIPTION
When attempting to remove a role from user i got this exception

> SyntaxException: WITH is required between SET and MATCH (line 3, column 1 (offset: 63))
> "OPTIONAL MATCH (u)-[rr1:IN_ROLE { UserId: $rr1.UserId }]->(r1:IdentityRole { NormalizedName: $r1.NormalizedName })"
>    ^

The fix of this issue is to add with instruction.